### PR TITLE
Add Vite-based 3D customizer scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,74 @@
-3D customizer
+# 3D Customizer
+
+A minimal React + Vite playground for designing branded overlays on a 3D cube in real-time. Update the
+headline, pick a font and color, and drop in a logo to see the texture regenerate instantly with Three.js.
+
+## Features
+
+- ⚛️ **React + Vite** scaffolding with hot-module reloading for rapid iteration.
+- 🎨 **Interactive controls** for text, font family, accent color, and logo uploads (with validation & preview).
+- 🧱 **Three.js scene** rendered via `@react-three/fiber`, including lighting, orbit controls, and a rotating cube.
+- 🖼️ **Dynamic texture generator** that composes text and imagery onto a canvas before projecting onto the 3D mesh.
+
+## Getting started
+
+1. Install dependencies:
+
+   ```bash
+   npm install
+   ```
+
+2. Start the dev server:
+
+   ```bash
+   npm run dev
+   ```
+
+   Vite prints the local URL (default `http://localhost:5173`). Open it in your browser to try the customizer.
+
+3. Build for production:
+
+   ```bash
+   npm run build
+   ```
+
+   Preview the production bundle locally with:
+
+   ```bash
+   npm run preview
+   ```
+
+## Usage tips
+
+- **Headline**: Enter any short text—this is centered near the top of the cube face.
+- **Font & color**: Choose from the provided font families and adjust the accent color, which shades text and
+  subtle background flourishes.
+- **Logo upload**: Supported formats include PNG, JPG, and SVG (max 2 MB). A live preview appears in the sidebar,
+  and you can remove the image with a single click.
+- **3D interaction**: Drag to orbit around the cube and scroll to zoom. The cube auto-rotates to show off the
+  generated texture.
+
+## Project structure
+
+```
+.
+├── index.html
+├── package.json
+├── public/
+│   └── vite.svg
+└── src/
+    ├── App.tsx
+    ├── components/
+    │   ├── ControlsPanel.tsx
+    │   └── CustomizerScene.tsx
+    ├── index.css
+    ├── main.tsx
+    ├── utils/
+    │   └── createOverlayTexture.ts
+    └── vite-env.d.ts
+```
+
+## License
+
+This project is provided as-is for demonstration purposes. Feel free to adapt it for your own prototypes or
+experiments.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>3D Customizer</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "3d_customizer",
+  "private": true,
+  "version": "0.0.1",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@react-three/drei": "^9.109.5",
+    "@react-three/fiber": "^8.15.10",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "three": "^0.160.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.37",
+    "@types/react-dom": "^18.2.15",
+    "@typescript-eslint/eslint-plugin": "^6.21.0",
+    "@typescript-eslint/parser": "^6.21.0",
+    "eslint": "^8.56.0",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-react-refresh": "^0.4.5",
+    "typescript": "^5.4.5",
+    "vite": "^5.2.0",
+    "@vitejs/plugin-react": "^4.2.1"
+  }
+}

--- a/public/vite.svg
+++ b/public/vite.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="410" height="404" viewBox="0 0 410 404" fill="none">
+  <path d="M399.641 59.5251L215.643 388.545C211.844 395.338 202.084 395.378 198.228 388.618L10.5817 59.5563C6.38087 52.1896 12.6802 43.2665 21.0281 44.7586L205.223 77.6824C206.398 77.8924 207.601 77.8905 208.776 77.6767L389.119 44.8058C397.439 43.2894 403.768 52.1434 399.641 59.5251Z" fill="url(#paint0_linear)"/>
+  <path d="M292.965 1.5744L156.801 28.2552C155.438 28.5237 154.197 29.2395 153.278 30.2697L15.515 184.697C9.69465 191.191 14.532 201.657 23.4663 202.145L108.131 206.719C109.585 206.797 110.999 206.31 112.087 205.356L307.135 34.5854C312.843 29.5802 308.222 20.0509 300.492 21.5759Z" fill="url(#paint1_linear)"/>
+  <defs>
+    <linearGradient id="paint0_linear" x1="6.00017" y1="32.9999" x2="235" y2="344" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#41D1FF"/>
+      <stop offset="1" stop-color="#BD34FE"/>
+    </linearGradient>
+    <linearGradient id="paint1_linear" x1="194.651" y1="8.81818" x2="236.076" y2="292.989" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FFEA83"/>
+      <stop offset="0.0833333" stop-color="#FFDD35"/>
+      <stop offset="1" stop-color="#FFA800"/>
+    </linearGradient>
+  </defs>
+</svg>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,105 @@
+import { useEffect, useMemo, useState } from 'react';
+import type { CanvasTexture } from 'three';
+import ControlsPanel from './components/ControlsPanel';
+import CustomizerScene from './components/CustomizerScene';
+import { createOverlayTexture, loadImageFromFile } from './utils/createOverlayTexture';
+
+const DEFAULT_TEXT = 'Custom Cube';
+const DEFAULT_FONT = 'Roboto';
+const DEFAULT_COLOR = '#ff6b6b';
+
+function App() {
+  const [text, setText] = useState(DEFAULT_TEXT);
+  const [fontFamily, setFontFamily] = useState(DEFAULT_FONT);
+  const [accentColor, setAccentColor] = useState(DEFAULT_COLOR);
+  const [logoFile, setLogoFile] = useState<File | null>(null);
+  const [logoPreviewUrl, setLogoPreviewUrl] = useState<string | null>(null);
+  const [logoImage, setLogoImage] = useState<HTMLImageElement | null>(null);
+  const [texture, setTexture] = useState<CanvasTexture | null>(null);
+
+  useEffect(() => {
+    let canceled = false;
+
+    if (!logoFile) {
+      setLogoPreviewUrl((previous) => {
+        if (previous) URL.revokeObjectURL(previous);
+        return null;
+      });
+      setLogoImage(null);
+      return () => {
+        canceled = true;
+      };
+    }
+
+    const previewUrl = URL.createObjectURL(logoFile);
+    setLogoPreviewUrl((previous) => {
+      if (previous) URL.revokeObjectURL(previous);
+      return previewUrl;
+    });
+
+    loadImageFromFile(logoFile)
+      .then((image) => {
+        if (!canceled) {
+          setLogoImage(image);
+        }
+      })
+      .catch((error) => {
+        console.error(error);
+      });
+
+    return () => {
+      canceled = true;
+      URL.revokeObjectURL(previewUrl);
+    };
+  }, [logoFile]);
+
+  useEffect(() => {
+    const newTexture = createOverlayTexture({
+      text,
+      fontFamily,
+      textColor: accentColor,
+      logo: logoImage,
+    });
+
+    setTexture((previous) => {
+      previous?.dispose();
+      return newTexture;
+    });
+
+    return () => {
+      newTexture.dispose();
+    };
+  }, [text, fontFamily, accentColor, logoImage]);
+
+  const sidebarProps = useMemo(
+    () => ({
+      text,
+      onTextChange: setText,
+      fontFamily,
+      onFontFamilyChange: setFontFamily,
+      color: accentColor,
+      onColorChange: setAccentColor,
+      onLogoSelected: setLogoFile,
+      logoPreview: logoPreviewUrl,
+    }),
+    [text, fontFamily, accentColor, logoPreviewUrl],
+  );
+
+  return (
+    <div className="app-shell">
+      <ControlsPanel {...sidebarProps} />
+      <main className="scene-wrapper">
+        <CustomizerScene texture={texture} />
+        <section className="scene-caption">
+          <h1>Interactive 3D Customizer</h1>
+          <p>
+            Update the text, pick a font, and upload your own brand assets. The cube will refresh with a
+            live texture composed with your selections.
+          </p>
+        </section>
+      </main>
+    </div>
+  );
+}
+
+export default App;

--- a/src/components/ControlsPanel.tsx
+++ b/src/components/ControlsPanel.tsx
@@ -1,0 +1,117 @@
+import { ChangeEvent, useMemo, useState } from 'react';
+
+interface ControlsPanelProps {
+  text: string;
+  onTextChange: (value: string) => void;
+  fontFamily: string;
+  onFontFamilyChange: (value: string) => void;
+  color: string;
+  onColorChange: (value: string) => void;
+  onLogoSelected: (file: File | null) => void;
+  logoPreview: string | null;
+}
+
+const FONT_OPTIONS = [
+  { label: 'Roboto', value: 'Roboto' },
+  { label: 'Montserrat', value: 'Montserrat' },
+  { label: 'Lora', value: 'Lora' },
+  { label: 'Courier Prime', value: 'Courier Prime' },
+];
+
+export function ControlsPanel({
+  text,
+  onTextChange,
+  fontFamily,
+  onFontFamilyChange,
+  color,
+  onColorChange,
+  onLogoSelected,
+  logoPreview,
+}: ControlsPanelProps) {
+  const [error, setError] = useState<string | null>(null);
+  const [fileInputKey, setFileInputKey] = useState(0);
+
+  const fontOptions = useMemo(() => FONT_OPTIONS, []);
+
+  const handleFileChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setError(null);
+    const file = event.target.files?.[0] ?? null;
+
+    if (!file) {
+      onLogoSelected(null);
+      return;
+    }
+
+    if (!file.type.startsWith('image/')) {
+      setError('Please upload a valid image file (PNG, JPG, SVG, etc.).');
+      setFileInputKey((value) => value + 1);
+      return;
+    }
+
+    if (file.size > 2 * 1024 * 1024) {
+      setError('Images must be smaller than 2MB.');
+      setFileInputKey((value) => value + 1);
+      return;
+    }
+
+    onLogoSelected(file);
+    event.target.value = '';
+  };
+
+  const handleRemoveLogo = () => {
+    onLogoSelected(null);
+    setError(null);
+    setFileInputKey((value) => value + 1);
+  };
+
+  return (
+    <aside className="controls-panel">
+      <h2>Customizer Controls</h2>
+      <label className="control">
+        <span>Headline Text</span>
+        <input
+          type="text"
+          value={text}
+          placeholder="Enter your product name"
+          onChange={(event) => onTextChange(event.target.value)}
+        />
+      </label>
+
+      <label className="control">
+        <span>Font Family</span>
+        <select value={fontFamily} onChange={(event) => onFontFamilyChange(event.target.value)}>
+          {fontOptions.map((font) => (
+            <option key={font.value} value={font.value}>
+              {font.label}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <label className="control">
+        <span>Accent Color</span>
+        <input type="color" value={color} onChange={(event) => onColorChange(event.target.value)} />
+      </label>
+
+      <label className="control">
+        <span>Upload Logo</span>
+        <input key={fileInputKey} type="file" accept="image/*" onChange={handleFileChange} />
+      </label>
+
+      {error ? <p className="error">{error}</p> : null}
+
+      {logoPreview ? (
+        <div className="logo-preview">
+          <img src={logoPreview} alt="Uploaded logo preview" />
+          <button type="button" onClick={handleRemoveLogo} className="secondary-button">
+            Remove logo
+          </button>
+        </div>
+      ) : (
+        <p className="helper">Accepted formats: PNG, JPG, SVG. Max size: 2MB.</p>
+      )}
+    </aside>
+  );
+}
+
+export default ControlsPanel;

--- a/src/components/CustomizerScene.tsx
+++ b/src/components/CustomizerScene.tsx
@@ -1,0 +1,60 @@
+import { Canvas } from '@react-three/fiber';
+import { OrbitControls, Environment } from '@react-three/drei';
+import { Suspense, useMemo, useRef } from 'react';
+import { CanvasTexture, Mesh } from 'three';
+import { useFrame } from '@react-three/fiber';
+
+interface CustomizerSceneProps {
+  texture: CanvasTexture | null;
+}
+
+function RotatingCube({ texture }: { texture: CanvasTexture | null }) {
+  const meshRef = useRef<Mesh>(null);
+
+  useFrame((_, delta) => {
+    if (!meshRef.current) return;
+    meshRef.current.rotation.y += delta * 0.4;
+    meshRef.current.rotation.x = 0.35;
+  });
+
+  const materialProps = useMemo(() => ({
+    map: texture ?? undefined,
+    color: texture ? undefined : '#ffffff',
+    metalness: 0.1,
+    roughness: 0.6,
+  }), [texture]);
+
+  return (
+    <mesh ref={meshRef} scale={2.4} castShadow receiveShadow>
+      <boxGeometry args={[1, 1, 1]} />
+      <meshStandardMaterial {...materialProps} />
+    </mesh>
+  );
+}
+
+export function CustomizerScene({ texture }: CustomizerSceneProps) {
+  return (
+    <Canvas
+      camera={{ position: [2.8, 2.2, 3.4], fov: 45 }}
+      shadows
+      className="scene-canvas"
+    >
+      <color attach="background" args={[0.95, 0.96, 1]} />
+      <ambientLight intensity={0.6} />
+      <directionalLight
+        position={[5, 10, 5]}
+        intensity={0.8}
+        castShadow
+        shadow-mapSize-width={2048}
+        shadow-mapSize-height={2048}
+      />
+      <Suspense fallback={null}>
+        <RotatingCube texture={texture} />
+        <Environment preset="studio" />
+      </Suspense>
+      <OrbitControls enablePan={false} maxPolarAngle={Math.PI / 2.1} />
+    </Canvas>
+  );
+}
+
+export default CustomizerScene;

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,160 @@
+@import url('https://fonts.googleapis.com/css2?family=Courier+Prime:wght@400;700&family=Lora:wght@400;600&family=Montserrat:wght@400;600;700&family=Roboto:wght@400;500;700&display=swap');
+
+:root {
+  color-scheme: light;
+  font-family: 'Roboto', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background-color: #f2f3f7;
+  color: #202631;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+}
+
+#root {
+  min-height: 100vh;
+}
+
+.app-shell {
+  display: flex;
+  min-height: 100vh;
+  width: 100%;
+}
+
+.controls-panel {
+  width: 320px;
+  padding: 2rem 1.5rem;
+  background: linear-gradient(180deg, #ffffff 0%, #f7f8fc 100%);
+  border-right: 1px solid rgba(31, 41, 55, 0.1);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.controls-panel h2 {
+  margin: 0 0 0.5rem;
+  font-size: 1.25rem;
+  font-weight: 700;
+}
+
+.control {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+}
+
+.control input[type='text'],
+.control select,
+.control input[type='file'] {
+  padding: 0.65rem 0.75rem;
+  border-radius: 0.6rem;
+  border: 1px solid rgba(31, 41, 55, 0.12);
+  background-color: #ffffff;
+  font-size: 0.95rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.control input[type='text']:focus,
+.control select:focus,
+.control input[type='file']:focus {
+  outline: none;
+  border-color: #526cff;
+  box-shadow: 0 0 0 3px rgba(82, 108, 255, 0.15);
+}
+
+.control input[type='color'] {
+  width: 100%;
+  height: 42px;
+  border-radius: 0.6rem;
+  padding: 0;
+  border: 1px solid rgba(31, 41, 55, 0.12);
+  background: #ffffff;
+}
+
+.helper {
+  font-size: 0.85rem;
+  color: rgba(31, 41, 55, 0.6);
+  margin: 0;
+}
+
+.error {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #c81e1e;
+}
+
+.logo-preview {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.logo-preview img {
+  max-width: 100%;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(31, 41, 55, 0.12);
+  padding: 0.75rem;
+  background-color: #ffffff;
+}
+
+.secondary-button {
+  padding: 0.5rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid rgba(31, 41, 55, 0.2);
+  background: #ffffff;
+  color: #1f2937;
+  font-size: 0.85rem;
+  cursor: pointer;
+  align-self: flex-start;
+}
+
+.secondary-button:hover {
+  border-color: rgba(31, 41, 55, 0.35);
+}
+
+.scene-wrapper {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  position: relative;
+}
+
+.scene-canvas {
+  flex: 1;
+  min-height: 60vh;
+}
+
+.scene-caption {
+  padding: 2rem 3rem 3rem;
+}
+
+.scene-caption h1 {
+  margin: 0 0 0.75rem;
+  font-size: 2rem;
+}
+
+.scene-caption p {
+  margin: 0;
+  max-width: 520px;
+  font-size: 1rem;
+  line-height: 1.6;
+  color: rgba(31, 41, 55, 0.75);
+}
+
+@media (max-width: 900px) {
+  .app-shell {
+    flex-direction: column;
+  }
+
+  .controls-panel {
+    width: 100%;
+    border-right: none;
+    border-bottom: 1px solid rgba(31, 41, 55, 0.1);
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/src/utils/createOverlayTexture.ts
+++ b/src/utils/createOverlayTexture.ts
@@ -1,0 +1,104 @@
+import { CanvasTexture, SRGBColorSpace } from 'three';
+
+export interface OverlayOptions {
+  text: string;
+  fontFamily: string;
+  textColor: string;
+  backgroundColor?: string;
+  logo?: HTMLImageElement | null;
+}
+
+const CANVAS_SIZE = 1024;
+const DEFAULT_BACKGROUND = '#f8f8f8';
+
+function drawText(ctx: CanvasRenderingContext2D, { text, fontFamily, textColor }: OverlayOptions) {
+  const fontSize = Math.floor(CANVAS_SIZE * 0.12);
+  ctx.fillStyle = textColor;
+  ctx.font = `700 ${fontSize}px ${fontFamily}, sans-serif`;
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  const textX = CANVAS_SIZE / 2;
+  const textY = CANVAS_SIZE * 0.35;
+  ctx.fillText(text || 'Your Brand', textX, textY, CANVAS_SIZE * 0.9);
+}
+
+function drawLogo(ctx: CanvasRenderingContext2D, logo?: HTMLImageElement | null) {
+  if (!logo) {
+    return;
+  }
+
+  const maxLogoWidth = CANVAS_SIZE * 0.35;
+  const maxLogoHeight = CANVAS_SIZE * 0.35;
+  const aspect = logo.width / logo.height;
+  let drawWidth = maxLogoWidth;
+  let drawHeight = drawWidth / aspect;
+
+  if (drawHeight > maxLogoHeight) {
+    drawHeight = maxLogoHeight;
+    drawWidth = drawHeight * aspect;
+  }
+
+  const padding = CANVAS_SIZE * 0.05;
+  const x = (CANVAS_SIZE - drawWidth) / 2;
+  const y = CANVAS_SIZE * 0.55;
+
+  ctx.drawImage(logo, x, y, drawWidth, drawHeight);
+
+  ctx.shadowColor = 'rgba(0, 0, 0, 0.25)';
+  ctx.shadowBlur = 24;
+  ctx.strokeStyle = 'rgba(255, 255, 255, 0.85)';
+  ctx.lineWidth = 6;
+  ctx.strokeRect(x - padding * 0.15, y - padding * 0.15, drawWidth + padding * 0.3, drawHeight + padding * 0.3);
+  ctx.shadowBlur = 0;
+}
+
+function drawDecorations(ctx: CanvasRenderingContext2D, textColor: string) {
+  const accentColor = textColor;
+  ctx.fillStyle = accentColor;
+  ctx.globalAlpha = 0.1;
+  const radius = CANVAS_SIZE * 0.45;
+  ctx.beginPath();
+  ctx.arc(CANVAS_SIZE * 0.5, CANVAS_SIZE * 0.5, radius, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.globalAlpha = 1;
+}
+
+export function createOverlayTexture(options: OverlayOptions): CanvasTexture {
+  const canvas = document.createElement('canvas');
+  canvas.width = CANVAS_SIZE;
+  canvas.height = CANVAS_SIZE;
+  const ctx = canvas.getContext('2d');
+
+  if (!ctx) {
+    throw new Error('Unable to acquire 2D context for overlay texture');
+  }
+
+  ctx.fillStyle = options.backgroundColor || DEFAULT_BACKGROUND;
+  ctx.fillRect(0, 0, CANVAS_SIZE, CANVAS_SIZE);
+
+  drawDecorations(ctx, options.textColor);
+  drawText(ctx, options);
+  drawLogo(ctx, options.logo ?? null);
+
+  const texture = new CanvasTexture(canvas);
+  texture.colorSpace = SRGBColorSpace;
+  texture.needsUpdate = true;
+
+  return texture;
+}
+
+export async function loadImageFromFile(file: File): Promise<HTMLImageElement> {
+  const dataUrl = await new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () => reject(reader.error ?? new Error('Failed to read file'));
+    reader.readAsDataURL(file);
+  });
+
+  return new Promise<HTMLImageElement>((resolve, reject) => {
+    const image = new Image();
+    image.onload = () => resolve(image);
+    image.onerror = () => reject(new Error('Unable to load image preview. Please try another file.'));
+    image.src = dataUrl;
+  });
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- scaffold a Vite + React TypeScript project with Three.js tooling
- add a configurable 3D cube scene and sidebar controls for text, font, color, and logo uploads
- implement canvas-based texture generation and refreshed project documentation

## Testing
- npm install *(fails: 403 Forbidden from npm registry in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68dbef2dc90483328e9633aa02ea4a95